### PR TITLE
Replace Icon with Scalable Version

### DIFF
--- a/src/data/nuclear-player-bin/PKGBUILD.template.ts
+++ b/src/data/nuclear-player-bin/PKGBUILD.template.ts
@@ -23,7 +23,12 @@ prepare() {
 }
 
 package()   {
+    iconDir=usr/share/icons/hicolor
+    scalableDir="$iconDir/scalable"
     install -dm0755 "\$pkgdir/"{opt,usr}
+    mv "$iconDir"/0x0 "$scalableDir"
+    rm "$scalableDir"/apps/nuclear.*
+    cp -a opt/nuclear/resources/media/presskit/icons/scalable/nuclear-icon.svg "$scalableDir"/apps/nuclear.svg
     cp -art "\$pkgdir" opt
     cp -art "\$pkgdir" usr
     install -Dm0644 -t "\$pkgdir/usr/share/licenses/\$_pkgname" LICENSE


### PR DESCRIPTION
KDE plasma does not seem to support the use of the `0x0` directory for placing icons.
Changes made in this PR will thus instead use the package's `.svg` icon as a `scablable` icon.

This PR depends on nukeop/nuclear#1661 as KDE Plasma won't show the icon properly otherwise.